### PR TITLE
Add feature for fetching current card prices

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -78,21 +78,19 @@ class App extends Component {
       .catch(err => console.log('decks error', err))
   }
 
-  initializeCardCount = (userCardsData) => {
-    userCardsData.forEach(card => {
-      if (card.cardCount === undefined) {
-        card.cardCount = 1
-      }
-    })
-    this.setState({ userCardsData },
-      localStorage.setItem('userCardsData', JSON.stringify(userCardsData)));
+  addUserCard = (cardName) => {
+    const newCard = this.state.cards.find(card => {
+      return cardName === card.cardName;
+    });
+    newCard.cardCount = 1;
+    const newUserCardsData = this.state.userCardsData.concat([newCard]);
+    this.setCardCount(newUserCardsData);
   }
-  
-  retrieveCardNames = (cardNames) => {
-    let userCardsData = this.state.cards.filter((card) => {
-      return cardNames.includes(card.cardName);
-    })
-    this.initializeCardCount(userCardsData);
+
+  removeUserCard = (indexToRemove) => {
+    const [...newUserCardsData] = this.state.userCardsData;
+    newUserCardsData.splice(indexToRemove, 1)
+    this.setCardCount(newUserCardsData);
   }
 
   setCardCount = (newUserCardsData) => {
@@ -101,7 +99,7 @@ class App extends Component {
   }
 
   setAsideView = (view) => {
-    this.setState( { asideView: view })
+    this.setState({ asideView: view })
   }
 
   removeFaveListItem = (indexToRemove) => {
@@ -115,7 +113,8 @@ class App extends Component {
     return (
       <div className="app">
         <Aside
-          retrieveCardNames={this.retrieveCardNames}
+          addUserCard={this.addUserCard}
+          removeUserCard={this.removeUserCard}
           setCardCount={this.setCardCount}
           userCardsData={this.state.userCardsData}
           cards={this.state.cards}

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -115,7 +115,6 @@ class App extends Component {
 
   setCurrentPrices = (cards) => {
     const newCards = cards.map(card => {
-      console.log(JSON.parse(localStorage.getItem('cardPrices')))
       const currentPrice = JSON.parse(localStorage.getItem('cardPrices'))
         .find(pricedCard => pricedCard.cardName.includes(card.cardName))
         .price;

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -6,14 +6,22 @@ import CardArea from '../CardArea/CardArea.js';
 class App extends Component {
   constructor() {
     super();
+    let storedUserCards = [];
+    let storedFaveDecks = [{ deckName: "Bant Spirits" }, { deckName: "Izzet Phoenix" }, { deckName: "Death's Shadow" }];
+    if (localStorage.getItem('userCardsData')) {
+      storedUserCards = JSON.parse(localStorage.getItem('userCardsData'));
+    }
+    if (localStorage.getItem('userFaveDecks')) {
+      storedFaveDecks = JSON.parse(localStorage.getItem('userFaveDecks'));
+    }
     this.state = {
       asideView: 'myCardList',
       cardAreaView: 'myCardList',
       cards: [],
       decks: [],
-      userCardsData: [],
+      userCardsData: storedUserCards,
       userDecks: [],
-      userFaveDecks: [{ deckName: "Bant Spirits" }, { deckName: "Izzet Phoenix" }, { deckName: "Death's Shadow" }]
+      userFaveDecks: storedFaveDecks
     };
   }
   
@@ -76,7 +84,8 @@ class App extends Component {
         card.cardCount = 1
       }
     })
-    this.setState({ userCardsData })
+    this.setState({ userCardsData },
+      localStorage.setItem('userCardsData', JSON.stringify(userCardsData)));
   }
   
   retrieveCardNames = (cardNames) => {
@@ -87,7 +96,8 @@ class App extends Component {
   }
 
   setCardCount = (newUserCardsData) => {
-    this.setState({ userCardsData: newUserCardsData })
+    this.setState({ userCardsData: newUserCardsData },
+      localStorage.setItem('userCardsData', JSON.stringify(newUserCardsData)));
   }
 
   setAsideView = (view) => {
@@ -97,7 +107,8 @@ class App extends Component {
   removeFaveListItem = (indexToRemove) => {
     const [...newFaveDecks] = this.state.userFaveDecks;
     newFaveDecks.splice(indexToRemove, 1)
-    this.setState({ userFaveDecks: newFaveDecks })
+    this.setState({ userFaveDecks: newFaveDecks },
+      localStorage.setItem('userFaveDecks', JSON.stringify(newFaveDecks)));
   }
 
   render() {

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -70,12 +70,59 @@ class App extends Component {
   componentDidMount() {
     fetch('https://whateverly-datasets.herokuapp.com/api/v1/cards')
       .then(cards => cards.json())
-      .then(parsedCards => this.setState({ cards: parsedCards.cards }))
+      .then(parsedCards => this.getCurrentPrices(parsedCards.cards))
       .catch(err => console.log('cards error', err))
     fetch('https://whateverly-datasets.herokuapp.com/api/v1/decks')
       .then(decks => decks.json())
       .then(parsedDecks => this.setState({ decks: parsedDecks.decks }))
       .catch(err => console.log('decks error', err))
+  }
+
+  getCurrentPrices = (cards) => {
+    let cardPrices;
+    const timeOfCache = JSON.parse(localStorage.getItem('timeOfCache'))
+    const twentyFourHours = 24 * 60 * 60 * 1000;
+    if (!timeOfCache || Date.now() - timeOfCache > twentyFourHours) {
+      const urlBase = 'https://api.scryfall.com/cards/search?q=f%3Am+unique%3Acards+%28';
+      const urlSuffix = cards.map(card => {
+        return `%21"${card.cardName.replace(/\s/g, '+')}"`;
+      });
+      Promise.all([
+        this.getPricePromise(urlBase + urlSuffix.slice(0,40).join('+or+') + '%29'),
+        this.getPricePromise(urlBase + urlSuffix.slice(40).join('+or+') + '%29')
+      ])
+        .then(priceData => {
+          const totalPriceData = priceData[0].concat(priceData[1]);
+          cardPrices = totalPriceData.map(card => {
+            return { cardName: card.name, price: card.usd };
+          });
+          localStorage.setItem('timeOfCache', JSON.stringify(Date.now()));
+          localStorage.setItem('cardPrices', JSON.stringify(cardPrices));
+          this.setCurrentPrices(cards);
+        })
+        .catch(err => console.log('Promise.all error', err));
+    } else {
+      this.setCurrentPrices(cards);
+    }
+  }
+
+  getPricePromise = (url) => {
+    return fetch(url)
+      .then(response => response.json())
+      .then(response => response.data)
+      .catch(err => console.log('price promise error', err));
+  }
+
+  setCurrentPrices = (cards) => {
+    const newCards = cards.map(card => {
+      console.log(JSON.parse(localStorage.getItem('cardPrices')))
+      const currentPrice = JSON.parse(localStorage.getItem('cardPrices'))
+        .find(pricedCard => pricedCard.cardName.includes(card.cardName))
+        .price;
+      card.price = parseFloat(currentPrice);
+      return card;
+    });
+    this.setState({ cards: newCards });
   }
 
   addUserCard = (cardName) => {

--- a/src/App/App.test.js
+++ b/src/App/App.test.js
@@ -1,9 +1,44 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import { shallow } from 'enzyme';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+const userCardsData = [
+  {
+    cardName: "Blood Moon",
+    cardCount: 1
+  },
+  {
+    cardName: "Mox Opal",
+    cardCount: 1
+  },
+];
+
+describe('App', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(
+      <App />
+    )
+  });
+  
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<App />, div);
+    ReactDOM.unmountComponentAtNode(div);
+  });
+
+  it('should save userCardsData in state when setCardCount is called', () => {
+    expect(wrapper.state('userCardsData').length).toEqual(0);
+    wrapper.instance().setCardCount(userCardsData);
+    expect(wrapper.state('userCardsData').length).toEqual(2);
+  });
+
+  it('should remove an element from userCardsData when removeUserCard is called', () => {
+    expect(wrapper.state('userCardsData').length).toEqual(2);
+    expect(wrapper.state('userCardsData')[0].cardName).toEqual('Blood Moon');
+    wrapper.instance().removeUserCard(0);
+    expect(wrapper.state('userCardsData').length).toEqual(1);
+    expect(wrapper.state('userCardsData')[0].cardName).toEqual('Mox Opal');
+  });
 });

--- a/src/Aside/Aside.js
+++ b/src/Aside/Aside.js
@@ -6,8 +6,12 @@ import './Aside.css';
 class Aside extends Component {
   constructor(props) {
     super(props);
+    let storedCardNames = [];
+    if (localStorage.getItem('cardNames')) {
+      storedCardNames = JSON.parse(localStorage.getItem('cardNames'));
+    }
     this.state = {
-      cardNames: [],
+      cardNames: storedCardNames,
       hasDuplicates: false,
       isInvalidCardName: false
     };
@@ -16,6 +20,7 @@ class Aside extends Component {
   addCardToList = (cardName) => {
     if (!this.state.cardNames.includes(cardName)) {
       const cardNames = this.state.cardNames.concat([cardName]);
+      localStorage.setItem('cardNames', JSON.stringify(cardNames));
       this.setState({
         cardNames: cardNames,
         hasDuplicates: false,

--- a/src/Aside/Aside.js
+++ b/src/Aside/Aside.js
@@ -7,8 +7,8 @@ class Aside extends Component {
   constructor(props) {
     super(props);
     let storedCardNames = [];
-    if (localStorage.getItem('cardNames')) {
-      storedCardNames = JSON.parse(localStorage.getItem('cardNames'));
+    if (props.userCardsData.length > 0) {
+      storedCardNames = props.userCardsData.map(card => card.cardName);
     }
     this.state = {
       cardNames: storedCardNames,
@@ -20,13 +20,12 @@ class Aside extends Component {
   addCardToList = (cardName) => {
     if (!this.state.cardNames.includes(cardName)) {
       const cardNames = this.state.cardNames.concat([cardName]);
-      localStorage.setItem('cardNames', JSON.stringify(cardNames));
       this.setState({
         cardNames: cardNames,
         hasDuplicates: false,
         isInvalidCardName: false,
       });
-      this.props.retrieveCardNames(cardNames);
+      this.props.addUserCard(cardName);
     } else {
       this.setState({ hasDuplicates: true });
     }
@@ -36,14 +35,14 @@ class Aside extends Component {
     const [...newCardNames] = this.state.cardNames;
     newCardNames.splice(indexToRemove, 1)
     this.setState({ cardNames: newCardNames })
-    this.props.retrieveCardNames(newCardNames);
+    this.props.removeUserCard(indexToRemove);
   }
 
   throwInvalidCardNameError = () => {
     this.setState({ isInvalidCardName: true });
   }
   
-  render(props) {
+  render() {
     return (
       <aside className="aside">
         <Controls addCardToList={this.addCardToList}

--- a/src/CardList/CardList.js
+++ b/src/CardList/CardList.js
@@ -11,7 +11,8 @@ class CardList extends Component {
   }
 
 
-  render(props) {
+  render() {
+    this.props.cardNames.sort();
     return (
       <div>
         <ul className="cardlist--ul">

--- a/src/CardListItem/CardListItem.js
+++ b/src/CardListItem/CardListItem.js
@@ -11,14 +11,8 @@ class CardListItem extends Component {
     };
   }
 
-  updateListItem = event => {
-    if (event.target.classList.contains("fa-trash-alt")) {
-      this.props.removeListItem(parseInt(event.target.closest("li").id));
-    } else if (event.target.classList.contains("fa-plus")) {
-      this.increaseCardCount();
-    } else if (event.target.classList.contains("fa-minus")) {
-      this.decreaseCardCount();
-    }
+  removeListItem = event => {
+    this.props.removeListItem(parseInt(event.target.closest("li").id));
   };
 
   increaseCardCount = props => {
@@ -47,16 +41,12 @@ class CardListItem extends Component {
 
   render() {
     return (
-      <li
-        onClick={this.updateListItem}
-        id={this.props.cardIndex}
-        className="cardlist--item"
-      >
+      <li id={this.props.cardIndex} className="cardlist--item">
         {this.props.cardName}
-        <i className="fas fa-minus" />
+        <i className="fas fa-minus" onClick={this.decreaseCardCount}/>
         <span>{this.state.count}</span>
-        <i className="fas fa-plus" />
-        <i className="far fa-trash-alt" />
+        <i className="fas fa-plus" onClick={this.increaseCardCount}/>
+        <i className="far fa-trash-alt" onClick={this.removeListItem}/>
       </li>
     );
   }

--- a/src/CardListItem/CardListItem.js
+++ b/src/CardListItem/CardListItem.js
@@ -5,7 +5,9 @@ class CardListItem extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      count: 1
+      count: props.userCardsData.find(card => {
+        return card.cardName === props.cardName;
+      }).cardCount
     };
   }
 
@@ -43,7 +45,7 @@ class CardListItem extends Component {
     return this.props.setCardCount(newUserCardsData);
   };
 
-  render(props) {
+  render() {
     return (
       <li
         onClick={this.updateListItem}

--- a/src/CardListItem/CardListItem.test.js
+++ b/src/CardListItem/CardListItem.test.js
@@ -33,57 +33,26 @@ describe("CardListItem", () => {
   });
 
   it("should call removeListItem when the trash-can is clicked", () => {
-    wrapper.find(".cardlist--item").simulate("click", {
-      target: {
-        classList: {
-          contains: className => {
-            if (className === "fa-trash-alt") {
-              return true;
-            }
-          }
-        },
-        closest: () => {
-          return { id: "0" };
-        }
-      }
+    wrapper.find(".fa-trash-alt").simulate("click", {
+      target: { closest: () => {return { id: "0" }} }
     });
     expect(removeListItemMock).toBeCalled();
-  });
-
-  it("should increment state count when plus sign is clicked", () => {
-    expect(wrapper.state("count")).toEqual(1);
-    wrapper.find(".cardlist--item").simulate("click", {
-      target: {
-        classList: {
-          contains: className => {
-            if (className === "fa-plus") {
-              return true;
-            }
-          }
-        }
-      }
-    });
-    expect(wrapper.state("count")).toEqual(2);
   });
 
   it("should decrement state count when minus sign is clicked", () => {
     wrapper.instance().increaseCardCount({userCardsData, cardName})
     expect(wrapper.state("count")).toEqual(2);
-    wrapper.find(".cardlist--item").simulate("click", {
-      target: {
-        classList: {
-          contains: className => {
-            if (className === "fa-minus") {
-              return true;
-            } 
-          }
-        }
-      }
-    });
+    wrapper.find(".fa-minus").simulate("click");
     expect(wrapper.state("count")).toEqual(1);
   });
 
-  it("should call setCardCount after CardListItem state is updated", () => {
+  it("should increment state count when plus sign is clicked", () => {
+    expect(wrapper.state("count")).toEqual(1);
+    wrapper.find(".fa-plus").simulate("click");
+    expect(wrapper.state("count")).toEqual(2);
+  });
+
+  it("should call setCardCount when updateUserCardsDataState is called", () => {
     wrapper.instance().updateUserCardsDataState();
     expect(setCardCountMock).toBeCalled();
   })

--- a/src/CardListItem/__snapshots__/CardListItem.test.js.snap
+++ b/src/CardListItem/__snapshots__/CardListItem.test.js.snap
@@ -4,20 +4,22 @@ exports[`CardListItem should match the snapshot 1`] = `
 <li
   className="cardlist--item"
   id={0}
-  onClick={[Function]}
 >
   Blood Moon
   <i
     className="fas fa-minus"
+    onClick={[Function]}
   />
   <span>
     1
   </span>
   <i
     className="fas fa-plus"
+    onClick={[Function]}
   />
   <i
     className="far fa-trash-alt"
+    onClick={[Function]}
   />
 </li>
 `;


### PR DESCRIPTION
Using the Scryfall.com API, I added a feature that updates the prices in our data set to the current market prices. Getting the URL figured out was tricky. The API URL uses the same syntax as Scryfall's search engine. After a certain character length, Scryfall truncates the URL, so the fetch call returns incomplete data. I had to break the the fetch call into two calls, and use Promise.all to wait for both calls to be resolved before manipulating the data.

Also since the API documentation says that the prices are only updated every 24 hours and recommends caching the data to avoid unnecessary fetch calls, I implemented a conditional statement to only fetch new price data if the last set of data is over 24 hours old.

#36 