### PR TITLE
Fix bugs for CardList, FaveList, and WishList

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -148,7 +148,16 @@ class App extends Component {
     });
     newCard.cardCount = 1;
     const newUserCardsData = this.state.userCardsData.concat([newCard]);
+    newUserCardsData.sort(this.sortCardsByName);
     this.saveArray('userCardsData', newUserCardsData);
+  }
+
+  sortCardsByName = (card1, card2) => {
+    if (card1.cardName < card2.cardName) {
+      return -1;
+    } else {
+      return 1;
+    }
   }
 
   saveArray = (arrayName, arrayToSave) => {
@@ -165,14 +174,28 @@ class App extends Component {
   }
 
   addToWishlist = (card) => {
-    card.wishListCount = 1;
-    const newWishList = this.state.wishList.concat([card]);
-    this.saveArray('wishList', newWishList);
+    const duplicate = this.state.wishList.find(wishlistCard => {
+      return wishlistCard.cardName === card.cardName;
+    });
+    if (!duplicate) {
+      card.wishListCount = 1;
+      const newWishList = this.state.wishList.concat([card]);
+      newWishList.sort(this.sortCardsByName);
+      this.saveArray('wishList', newWishList);
+    }
   }
 
   addToFaveDecks = (deck) => {
-    const newFaveDecks = this.state.faveDecks.concat([deck]);
-    this.saveArray('faveDecks', newFaveDecks);
+    const duplicate = this.state.faveDecks.find(faveDeck => {
+      return faveDeck.deckName === deck.deckName;
+    });
+    if (!duplicate) {
+      const newFaveDecks = this.state.faveDecks.concat([deck]);
+      newFaveDecks.sort((a, b) => {
+        return a.deckName < b.deckName ? -1 : 1;
+      });
+      this.saveArray('faveDecks', newFaveDecks);
+    }
   }
 
   render() {

--- a/src/App/App.test.js
+++ b/src/App/App.test.js
@@ -8,7 +8,8 @@ const userCardsData = [
   { cardName: "Mox Opal", cardCount: 1 }
 ];
 const wishList = [
-  { cardName: "Jace, the Mind Sculptor", wishListCount: 4 }
+  { cardName: "Jace, the Mind Sculptor", wishListCount: 4 },
+  { cardName: "Ancestral Recall", wishListCount: 1 }
 ];
 const deck = { deckName: 'Izzet Phoenix' };
 
@@ -44,12 +45,43 @@ describe('App', () => {
     expect(wrapper.state('wishList').length).toEqual(0);
     wrapper.instance().addToWishlist(wishList[0]);
     expect(wrapper.state('wishList').length).toEqual(1);
+    wrapper.instance().saveArray('wishList', []);
   });
-
+  
+  it(`should not add a card to state.wishList when addToWishList is called
+  if that card is already in the wishlist`, () => {
+    expect(wrapper.state('wishList').length).toEqual(0);
+    wrapper.instance().addToWishlist(wishList[0]);
+    expect(wrapper.state('wishList').length).toEqual(1);
+    wrapper.instance().addToWishlist(wishList[0]);
+    expect(wrapper.state('wishList').length).toEqual(1);
+  });
+  
   it('should add a deck to state.faveDecks when addToFaveDecks is called',
-    () => {
+  () => {
     expect(wrapper.state('faveDecks').length).toEqual(0);
     wrapper.instance().addToFaveDecks(deck);
     expect(wrapper.state('faveDecks').length).toEqual(1);
+    wrapper.instance().saveArray('faveDecks', []);
+  });
+  
+  it(`should not add a deck to state.faveDecks when addToFaveDecks is called
+    if that deck is already in faveDecks`, () => {
+    expect(wrapper.state('faveDecks').length).toEqual(0);
+    wrapper.instance().addToFaveDecks(deck);
+    expect(wrapper.state('faveDecks').length).toEqual(1);
+    wrapper.instance().addToFaveDecks(deck);
+    expect(wrapper.state('faveDecks').length).toEqual(1);
+  });
+
+  it('should sort card objects when sortCardsByName is called', () => {
+    const userCardsData = [
+      { cardName: 'Blood Moon' }, 
+      { cardName: 'Breeding Pool' },
+      { cardName: 'Arid Mesa' }
+    ];
+    expect(userCardsData[0].cardName).toEqual('Blood Moon');
+    userCardsData.sort(wrapper.instance().sortCardsByName);
+    expect(userCardsData[0].cardName).toEqual('Arid Mesa');
   });
 });

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -39,6 +39,12 @@ class Card extends Component {
             />
             <div className="counter--container">
               <p>{this.props.card.price}</p>
+              <p>
+                {
+                  `You have ${this.props.card.userCount}
+                   of ${this.props.card.requiredCount}`
+                }
+              </p>
               <button onClick={this.addToWishlist}>
                 Add to Wishlist
               </button>

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -3,7 +3,6 @@ import '../styles/main.scss';
 
 class Card extends Component {
   setPopUpData = () => {
-    console.log(this.props.cardAreaView)
     this.props.displayPopUp(this.props.card);
   }
 

--- a/src/Card/Card.test.js
+++ b/src/Card/Card.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import Card from './Card';
+import { shallow } from 'enzyme';
+
+const displayPopUpMock = jest.fn();
+const addToWishlistMock = jest.fn();
+const card = { cardName: 'Black Lotus' };
+
+describe('Card', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <Card
+      card={card} 
+      key={card.cardName}
+      cardAreaView={'expandedDeck'}
+      displayPopUp={displayPopUpMock}
+      addToWishlist={addToWishlistMock}/>
+    );
+  });
+
+  it('should match the snapshot when cardAreaView is myCardList', () => {
+    let wrapper = shallow(
+      <Card
+        card={card} 
+        key={card.cardName}
+        cardAreaView={'myCardList'}
+        displayPopUp={displayPopUpMock}/>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+  
+  it('should match the snapshot when cardAreaView is expandedDeck', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should call props.displayPopUp when the image is clicked', () => {
+    wrapper.find('.card--image').simulate('click');
+    expect(displayPopUpMock).toBeCalled();
+  });
+  
+  it('should call props.addToWishlist when the button is clicked', () => {
+    wrapper.find('button').simulate('click');
+    expect(addToWishlistMock).toBeCalled();
+  });
+});

--- a/src/Card/__snapshots__/Card.test.js.snap
+++ b/src/Card/__snapshots__/Card.test.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card should match the snapshot when cardAreaView is expandedDeck 1`] = `
+<article
+  className="card--container"
+>
+  <div>
+    <img
+      alt="Black Lotus"
+      className="card--image"
+      onClick={[Function]}
+    />
+    <div
+      className="counter--container"
+    >
+      <p />
+      <p>
+        You have undefined
+                   of undefined
+      </p>
+      <button
+        onClick={[Function]}
+      >
+        Add to Wishlist
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`Card should match the snapshot when cardAreaView is myCardList 1`] = `
+<article
+  className="card--container"
+>
+  <div>
+    <img
+      alt="Black Lotus"
+      className="card--image"
+      onClick={[Function]}
+    />
+    <div
+      className="card--counter-container"
+    >
+      <h1
+        className="card--counter"
+      >
+        X
+      </h1>
+    </div>
+  </div>
+</article>
+`;

--- a/src/CardArea/CardArea.js
+++ b/src/CardArea/CardArea.js
@@ -14,16 +14,7 @@ class CardArea extends Component {
     };
   }
 
-  sortCardsByName(card1, card2) {
-    if (card1.cardName < card2.cardName) {
-      return -1;
-    } else {
-      return 1;
-    }
-  }
-
   sortCards() {
-    this.props.userCardsData.sort(this.sortCardsByName);
     return this.props.userCardsData.map(userCard => {
       return (
         <Card

--- a/src/CardArea/CardArea.js
+++ b/src/CardArea/CardArea.js
@@ -10,7 +10,7 @@ class CardArea extends Component {
     this.state = {
       popUpCard: {},
       showPopUp: false,
-      selectedDeck: []
+      cardsInDeck: []
     };
   }
 
@@ -61,12 +61,21 @@ class CardArea extends Component {
   }
   
   expandDeck = (deckObj) => {
-    const selectedDeck = this.props.getExpandedDeckInfo(deckObj)
-    this.setState({ selectedDeck });
+    const cardsInDeck = this.props.getExpandedDeckInfo(deckObj);
+    cardsInDeck.map(cardInDeck => {
+      const matchedCard = this.props.userCardsData.find(userCard => {
+        return userCard.cardName === cardInDeck.cardName;
+      });
+      cardInDeck.requiredCount = deckObj.cardCounts[cardInDeck.cardName];
+      cardInDeck.userCount = matchedCard ? 
+        Math.min(cardInDeck.requiredCount, matchedCard.cardCount) : 0;
+      return cardInDeck;
+    });
+    this.setState({ cardsInDeck });
   }
 
   displayDeck = () => {
-    return this.state.selectedDeck.map(card => {
+    return this.state.cardsInDeck.map(card => {
       return (
         <Card
           card={card} 

--- a/src/CardArea/CardArea.test.js
+++ b/src/CardArea/CardArea.test.js
@@ -30,15 +30,4 @@ describe('CardArea', () => {
   it('should match the snapshot', () => {
     expect(wrapper).toMatchSnapshot();
   });
-
-  it('should sort card objects when sortCardsByName is called', () => {
-    const userCardsData = [
-      { cardName: 'Blood Moon' }, 
-      { cardName: 'Breeding Pool' },
-      { cardName: 'Arid Mesa' }
-    ];
-    expect(userCardsData[0].cardName).toEqual('Blood Moon');
-    userCardsData.sort(wrapper.instance().sortCardsByName);
-    expect(userCardsData[0].cardName).toEqual('Arid Mesa');
-  });
 });

--- a/src/CardArea/__snapshots__/CardArea.test.js.snap
+++ b/src/CardArea/__snapshots__/CardArea.test.js.snap
@@ -13,16 +13,6 @@ exports[`CardArea should match the snapshot 1`] = `
     <Card
       card={
         Object {
-          "cardName": "Arid Mesa",
-        }
-      }
-      cardAreaView="myCardList"
-      displayPopUp={[Function]}
-      key="Arid Mesa"
-    />
-    <Card
-      card={
-        Object {
           "cardName": "Blood Moon",
         }
       }
@@ -39,6 +29,16 @@ exports[`CardArea should match the snapshot 1`] = `
       cardAreaView="myCardList"
       displayPopUp={[Function]}
       key="Breeding Pool"
+    />
+    <Card
+      card={
+        Object {
+          "cardName": "Arid Mesa",
+        }
+      }
+      cardAreaView="myCardList"
+      displayPopUp={[Function]}
+      key="Arid Mesa"
     />
   </section>
 </div>

--- a/src/FaveList/FaveList.js
+++ b/src/FaveList/FaveList.js
@@ -3,19 +3,17 @@ import FaveListItem from '../FaveListItem/FaveListItem.js'
 import '../styles/main.scss';
 
 function FaveList(props) {
-  const faveDeckNames = props.faveDecks.map(deck => deck.deckName);
-  faveDeckNames.sort();
   return(
     <div>
       <h1>My Favorite Decks:</h1>
       <ul>
         {
-          faveDeckNames.map((deck, index) => {
+          props.faveDecks.map((deck, index) => {
             return (
             <FaveListItem
-              deckName={deck}
+              deckName={deck.deckName}
               deckIndex={index}
-              key={deck}
+              key={deck.deckName}
               faveDecks={props.faveDecks}
               saveArray={props.saveArray}/>
             )


### PR DESCRIPTION
I added conditionals to the `addToWishlist` and `addToFaveDecks` methods in App so that duplicate cards and decks would not be put in the lists. The bug where deleting items from the list would sometimes delete the wrong thing was caused by doing the sorting on render. I refactored the methods so that they sorted the arrays before they were set in state, and this solved the problem.